### PR TITLE
Release docker images for ARM64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,11 @@
 sudo: required
-language: java
-jdk:
-  - openjdk8
+jobs:
+  - arch: amd64
+    language: java
+    jdk: openjdk8
+  - arch: arm64
+    language: python 
+    python: 3.6    
 
 # See https://docs.travis-ci.com/user/languages/java/#caching
 before_cache:
@@ -68,11 +72,13 @@ before_install:
   - docker run -d -e SWAGGER_HOST=http://petstore.swagger.io -e SWAGGER_BASE_PATH=/v2 -p 80:8080 swaggerapi/petstore
   - docker ps -a
   # install crystal
-  - curl -sSL https://dist.crystal-lang.org/apt/setup.sh | sudo bash
-  - curl -sL "https://keybase.io/crystal/pgp_keys.asc" | sudo apt-key add -
-  - echo "deb https://dist.crystal-lang.org/apt crystal main" | sudo tee /etc/apt/sources.list.d/crystal.list
-  - sudo apt-get update
-  - sudo apt install crystal
+  - if [[ "${TRAVIS_CPU_ARCH}" != "arm64" ]]; then
+       curl -sSL https://dist.crystal-lang.org/apt/setup.sh | sudo bash;
+       curl -sL "https://keybase.io/crystal/pgp_keys.asc" | sudo apt-key add -;
+       echo "deb https://dist.crystal-lang.org/apt crystal main" | sudo tee /etc/apt/sources.list.d/crystal.list;
+       sudo apt-get update;
+       sudo apt install crystal;
+    fi
   - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.22.0
   - export PATH="$HOME/.yarn/bin:$PATH"
   # install rust
@@ -102,7 +108,11 @@ before_install:
   #- sudo apt-get install dart
   # switch to php7
   - phpenv versions
-  - phpenv global 7.2.15
+  - if [ "${TRAVIS_CPU_ARCH}" == "arm64" ]; then
+      phpenv global 7.2.31;
+    else
+      phpenv global 7.2.15;
+    fi
   - php -v
   # comment out below as installation failed in travis
   # Add rebar3 build tool and recent Erlang/OTP for Erlang petstore server tests.
@@ -131,9 +141,22 @@ before_install:
     fi;
   - pushd .; cd website; yarn install; popd
   # install Deno
-  - sh -s v1.6.2 < ./CI/deno_install.sh
-  - export PATH="$HOME/.deno/bin:$PATH"
 
+  - if [ "${TRAVIS_CPU_ARCH}" == "arm64" ]; then
+      git clone https://github.com/denoland/deno/;
+      curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y -v;
+      sudo apt install -qq libglib2.0-dev;
+      export PATH=$PATH:$HOME/.cargo/bin;
+      cd deno;
+      cargo build -vv 2> /dev/null;
+      cd ..;
+    else
+      sh -s v1.6.2 < ./CI/deno_install.sh;    
+      export PATH="$HOME/.deno/bin:$PATH";
+    fi
+  - if [ "${TRAVIS_CPU_ARCH}" == "arm64" ]; then
+      sudo apt-get install -qq maven;
+    fi
 install:
   # Add Godeps dependencies to GOPATH and PATH
   #- eval "$(curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | GIMME_GO_VERSION=1.4 bash)"
@@ -159,11 +182,16 @@ script:
   - /bin/bash ./bin/utils/detect_tab_in_java_class.sh
   # run integration tests defined in maven pom.xml
   # WARN: Travis will timeout after 10 minutes of no stdout/stderr activity, which is problematic with mvn --quiet.
-  - mvn -e --no-snapshot-updates --quiet --batch-mode --show-version clean install -Dorg.slf4j.simpleLogger.defaultLogLevel=error
-  - mvn -e --no-snapshot-updates --quiet --batch-mode --show-version verify -Psamples -Dorg.slf4j.simpleLogger.defaultLogLevel=error
+  - if [ "${TRAVIS_CPU_ARCH}" == "arm64" ]; then
+      mvn clean install 2> /dev/null;
+      mvn verify 2> /dev/null;
+    else
+      mvn -e --no-snapshot-updates --quiet --batch-mode --show-version clean install -Dorg.slf4j.simpleLogger.defaultLogLevel=error;
+      mvn -e --no-snapshot-updates --quiet --batch-mode --show-version verify -Psamples -Dorg.slf4j.simpleLogger.defaultLogLevel=error;
+    fi
 after_success:
   # push to maven repo
-  - if [ $SONATYPE_USERNAME ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+  - if [ $SONATYPE_USERNAME ] && [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "${TRAVIS_CPU_ARCH}" == "amd64" ]; then
       if [ "$TRAVIS_BRANCH" = "master" ] && [ -z $TRAVIS_TAG ]; then
         echo "Publishing from branch $TRAVIS_BRANCH";
         mvn clean deploy -DskipTests=true -B -U -P release --settings CI/settings.xml;
@@ -199,7 +227,11 @@ after_success:
       export build_date=$(date -u +"%Y-%m-%dT%H:%M:%SZ");
       docker build --label=org.opencontainers.image.created=$build_date --label=org.opencontainers.image.title=openapi-generator-online --label=org.opencontainers.image.revision=$TRAVIS_COMMIT --label=org.opencontainers.image.version=$cli_version -t $DOCKER_GENERATOR_IMAGE_NAME ./modules/openapi-generator-online;
       if [ ! -z "$TRAVIS_TAG" ]; then
+        if [ "${TRAVIS_CPU_ARCH}" == "arm64" ]; then
+          docker tag $DOCKER_GENERATOR_IMAGE_NAME:latest $DOCKER_GENERATOR_IMAGE_NAME:${TRAVIS_TAG}-arm64;
+        else
           docker tag $DOCKER_GENERATOR_IMAGE_NAME:latest $DOCKER_GENERATOR_IMAGE_NAME:$TRAVIS_TAG;
+        fi;  
       fi;
       if [ ! -z "$TRAVIS_TAG" ] || [ "$TRAVIS_BRANCH" = "master" ]; then
           docker push $DOCKER_GENERATOR_IMAGE_NAME && echo "Pushed to $DOCKER_GENERATOR_IMAGE_NAME";
@@ -213,7 +245,11 @@ after_success:
       export build_date=$(date -u +"%Y-%m-%dT%H:%M:%SZ");
       docker build --label=org.opencontainers.image.created=$build_date --label=org.opencontainers.image.title=openapi-generator-cli --label=org.opencontainers.image.revision=$TRAVIS_COMMIT --label=org.opencontainers.image.version=$cli_version -t $DOCKER_CODEGEN_CLI_IMAGE_NAME ./modules/openapi-generator-cli;
       if [ ! -z "$TRAVIS_TAG" ]; then
+        if [ "${TRAVIS_CPU_ARCH}" == "arm64" ]; then
+          docker tag $DOCKER_CODEGEN_CLI_IMAGE_NAME:latest $DOCKER_CODEGEN_CLI_IMAGE_NAME:${TRAVIS_TAG}-arm64;
+        else
           docker tag $DOCKER_CODEGEN_CLI_IMAGE_NAME:latest $DOCKER_CODEGEN_CLI_IMAGE_NAME:$TRAVIS_TAG;
+        fi;  
       fi;
       if [ ! -z "$TRAVIS_TAG" ] || [ "$TRAVIS_BRANCH" = "master" ]; then
           docker push $DOCKER_CODEGEN_CLI_IMAGE_NAME;
@@ -221,7 +257,7 @@ after_success:
       fi;
     fi;
   ## publish latest website, variables below are secure environment variables which are unavailable to PRs from forks.
-  - if [ "$TRAVIS_BRANCH" = "master" ] && [ -z $TRAVIS_TAG ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+  - if [ "$TRAVIS_BRANCH" = "master" ] && [ -z $TRAVIS_TAG ] && [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "${TRAVIS_CPU_ARCH}" == "amd64" ]; then
       cd website;
       git config --global user.name "${GH_NAME}";
       git config --global user.email "${GH_EMAIL}";

--- a/modules/openapi-generator-cli/Dockerfile
+++ b/modules/openapi-generator-cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-jre-alpine
+FROM openjdk:8-jre-alpine
 
 RUN apk add --no-cache bash
 


### PR DESCRIPTION
Hi

Package Owner: Abhishek Nishant

PR change Details:
1. Patch Details: Following 2 files have been modified :

.travis.yml: Added language to python for arm64 so that python3.6 virtual environment is created in arm64 and  phpenv global' to 7.2.31 is used for arm64 and code is added to install deno for arm64 and to build the jar of this package mvn clean install and mvn verify command is used for arm64. some code changes are done to build image and push to Docker Hub.
./modules/openapi-generator-cli/Dockerfile: java:8-jre-alpine is replaced with openjdk:8-jre-alpine to build image for arm64.

2. Testing Detail:
Please find my Travis-ci testing jobs here: <https://travis-ci.com/github/nightfurytoothlesss/openapi-generator/jobs/455333759>

3. PR Description: Here is my commit message :
   Release docker images for ARM64:

Added language to python for arm64 so that python3.6 virtual environment is created in arm64 and  phpenv global' to 7.2.31 is used for arm64 and code is added to install deno for arm64 and to build the jar of this package mvn clean install and mvn verify command is used for arm64. some code changes are done to build image and push to Docker Hub.
Replaced java:8-jre-alpine with openjdk:8-jre-alpine to build image for arm64.


Signed-off-by: odidev odidev@puresoftware.com

4. Reviewer: Pruthvi Teja Reddy & Shobhit Parashari

Thanks
Abhishek Nishant
